### PR TITLE
I've added a GitHub Actions workflow for C++ Continuous Integration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
     - name: Build
       run: cmake --build build --config Release
+    - name: List build directory
+      run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
@@ -35,8 +37,10 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
+     - name: List build directory
+       run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
         name: my_project_windows
-        path: build/${{ env.BUILD_CONFIG }}/my_project.exe
+        path: build/my_project.exe # Corrected path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake g++
     - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
@@ -35,8 +35,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-    - name: List build directory
-      run: ls -R build
+     - name: List build directory
+       run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,11 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
     - name: Build
       run: cmake --build build --config Release
-    - name: List build directory
-      run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
-        name: my_project_ubuntu
-        path: build/my_project
+         name: ajazz_time_correction_tool_ubuntu # Corrected artifact name
+         path: build/ajazz_time_correction_tool    # Corrected artifact path
 
   build_windows:
     runs-on: windows-latest
@@ -37,10 +35,10 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-    - name: List build directory
-      run: ls -R build
+     - name: List build directory
+       run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
-        name: my_project_windows
-        path: build/my_project.exe # Corrected path
+         name: ajazz_time_correction_tool_windows # Corrected artifact name
+         path: build/Release/ajazz_time_correction_tool.exe # Corrected artifact path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
       with:
         name: my_project_ubuntu
         path: build/my_project
@@ -36,7 +36,7 @@ jobs:
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
       with:
         name: my_project_windows
         path: build/${{ env.BUILD_CONFIG }}/my_project.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake g++
     - name: Configure CMake
-       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
@@ -35,8 +35,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-     - name: List build directory
-       run: ls -R build
+    - name: List build directory
+      run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Changed from ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
@@ -16,7 +16,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake g++
     - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
+       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
@@ -35,8 +35,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-    - name: List build directory
-      run: ls -R build
+     - name: List build directory
+       run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
-       uses: actions/upload-artifact@v4
+       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
         name: my_project_ubuntu
         path: build/my_project
@@ -36,7 +36,7 @@ jobs:
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
     - name: Upload artifact
-       uses: actions/upload-artifact@v4
+       uses: actions/upload-artifact@v4 # Corrected indentation
       with:
         name: my_project_windows
         path: build/${{ env.BUILD_CONFIG }}/my_project.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: C++ CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake g++
+    - name: Configure CMake
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+    - name: Build
+      run: cmake --build build --config Release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: my_project_ubuntu
+        path: build/my_project
+
+  build_windows:
+    runs-on: windows-latest
+    env:
+      BUILD_CONFIG: Release # Define an environment variable for build configuration
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure CMake
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
+    - name: Build
+      run: cmake --build build --config ${{ env.BUILD_CONFIG }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: my_project_windows
+        path: build/${{ env.BUILD_CONFIG }}/my_project.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-     - name: List build directory
-       run: ls -R build
+    - name: List build directory
+      run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: cmake --build build --config Release
     - name: Upload artifact
-       uses: actions/upload-artifact@v4 # Corrected indentation
+      uses: actions/upload-artifact@v4 # Corrected indentation
       with:
         name: my_project_ubuntu
         path: build/my_project
@@ -36,7 +36,7 @@ jobs:
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
     - name: Upload artifact
-       uses: actions/upload-artifact@v4 # Corrected indentation
+      uses: actions/upload-artifact@v4 # Corrected indentation
       with:
         name: my_project_windows
         path: build/${{ env.BUILD_CONFIG }}/my_project.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,8 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_CONFIG }}
     - name: Build
       run: cmake --build build --config ${{ env.BUILD_CONFIG }}
-     - name: List build directory
-       run: ls -R build
+    - name: List build directory
+      run: ls -R build
     - name: Upload artifact
       uses: actions/upload-artifact@v4 # Corrected indentation
       with:


### PR DESCRIPTION
This workflow will build your project in both Ubuntu and Windows environments.

Here are the key features:
- It triggers automatically when you push to the `main` branch or when a pull request targets `main`.
- There are separate processes for `ubuntu-latest` and `windows-latest`.
- For each process:
    - I'll check out your code.
    - I'll set up the C++ build environment, including CMake and the appropriate compiler.
    - I'll configure your project using CMake.
    - Then, I'll build the executable.
    - Finally, I'll upload the compiled executable as a build artifact.

The Ubuntu process uses GCC and Make, while the Windows process uses MSVC. The executables will be named `my_project_ubuntu` and `my_project_windows` respectively in the artifacts.