### PR TITLE
Integrate hidapi with Zig build and list HID devices in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,29 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mlugg/setup-zig@v2
 
+    # Install hidapi for Linux
+    - name: Install hidapi dependencies and build tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libudev-dev libusb-1.0-0-dev pkg-config autoconf automake libtool
+    - name: Clone hidapi repository
+      run: git clone https://github.com/libusb/hidapi.git hidapi_src
+    - name: Build and install hidapi
+      run: |
+        cd hidapi_src
+        ./bootstrap
+        ./configure --prefix=$GITHUB_WORKSPACE/hidapi_install CFLAGS="-fPIC"
+        make
+        make install
+        cd ..
+
     # Build for Linux (native)
     - name: Build executable (Linux)
       run: zig build
       # Output will be in zig-out/bin/app
+
+    - name: Run HID device lister
+      run: ./zig-out/bin/app
 
     - name: Upload executable (Linux)
       uses: actions/upload-artifact@v4

--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,31 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // --- START HIDAPI INTEGRATION ---
+    // Assuming hidapi is installed in "hidapi_install" at the root of the project in the GHA environment
+    // $GITHUB_WORKSPACE/hidapi_install
+    // addIncludePath needs path to the directory containing 'hidapi.h' or the 'hidapi' directory itself.
+    // If hidapi.h is at 'hidapi_install/include/hidapi/hidapi.h', then use:
+    exe.addIncludePath(b.path("hidapi_install/include/hidapi"));
+    // If hidapi.h is at 'hidapi_install/include/hidapi.h', then use:
+    // exe.addIncludePath(b.path("hidapi_install/include"));
+
+    // Add library path for libhidapi-hidraw.a
+    exe.addLibraryPath(b.path("hidapi_install/lib"));
+
+    // Link against the static hidapi-hidraw library
+    //addObjectFile expects a path to the .a or .o file
+    exe.addObjectFile(b.path("hidapi_install/lib/libhidapi-hidraw.a"));
+
+    // Link against udev and usb-1.0, which hidapi depends on.
+    // These are system libraries, so linkSystemLibrary is appropriate.
+    // This is only needed for Linux.
+    if (exe.target.isLinux()) {
+        exe.linkSystemLibrary("udev");
+        exe.linkSystemLibrary("usb-1.0");
+    }
+    // --- END HIDAPI INTEGRATION ---
+
     b.installArtifact(exe);
 
     // Optional: Define a step to run the executable

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,81 @@
 const std = @import("std");
+const c = @cImport({
+    @cInclude("hidapi/hidapi.h");
+});
+
+// Helper function to print a wchar_t C string.
+fn printWcharString(writer: std.io.AnyWriter, prefix: []const u8, wstr: ?[*]const c.wchar_t, allocator: std.mem.Allocator) !void {
+    if (wstr == null) {
+        try writer.print("{s} (null)\n", .{prefix});
+        return;
+    }
+
+    var temp_buf = std.ArrayList(u8).init(allocator);
+    defer temp_buf.deinit();
+
+    var i: usize = 0;
+    while (wstr.?[i] != 0) : (i += 1) {
+        const wide_char = wstr.?[i];
+        if (wide_char > 0 and wide_char <= 127) { // Printable ASCII
+            try temp_buf.append(@intCast(u8, wide_char));
+        } else {
+            try temp_buf.append('?'); // Placeholder
+        }
+    }
+
+    if (temp_buf.items.len == 0) {
+        try writer.print("{s} (empty or non-printable)\n", .{prefix});
+    } else {
+        try writer.print("{s} {s}\n", .{prefix, temp_buf.items});
+    }
+}
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
-    try stdout.print("Hello, world!\n", .{});
+    const stdout_writer = std.io.getStdOut().writer();
+    const allocator = std.heap.page_allocator;
+
+    if (c.hid_init() != 0) {
+        try stdout_writer.print("Failed to initialize HIDAPI\n", .{}); // Escaped newline
+        std.process.exit(1);
+    }
+    defer {
+        _ = c.hid_exit();
+    }
+
+    var enumerated_devices = c.hid_enumerate(0x0, 0x0);
+    if (enumerated_devices == null) {
+        try stdout_writer.print("No HID devices found, or an error occurred during enumeration.\n", .{}); // Escaped newline
+        return;
+    }
+    defer c.hid_free_enumeration(enumerated_devices);
+
+    var current_device_node = enumerated_devices;
+    var device_counter: u32 = 0;
+
+    try stdout_writer.print("Scanning for HID devices...\n\n", .{}); // Escaped newlines
+
+    while (current_device_node != null) : (current_device_node = current_device_node.?.next) {
+        device_counter += 1;
+        try stdout_writer.print("Device {d}:\n", .{device_counter}); // Escaped newline
+
+        if (current_device_node.?.path != null) {
+            try stdout_writer.print("  Path: {s}\n", .{std.mem.span(current_device_node.?.path)}); // Escaped newline
+        } else {
+            try stdout_writer.print("  Path: (null)\n", .{}); // Escaped newline
+        }
+
+        try stdout_writer.print("  Vendor ID: 0x{x:04}\n", .{current_device_node.?.vendor_id}); // Escaped newline
+        try stdout_writer.print("  Product ID: 0x{x:04}\n", .{current_device_node.?.product_id}); // Escaped newline
+
+        try printWcharString(stdout_writer, "  Manufacturer:", current_device_node.?.manufacturer_string, allocator);
+        try printWcharString(stdout_writer, "  Product:", current_device_node.?.product_string, allocator);
+
+        try stdout_writer.print("\n", .{}); // Escaped newline
+    }
+
+    if (device_counter == 0) {
+        try stdout_writer.print("No HID devices were ultimately processed from the list.\n", .{}); // Escaped newline
+    } else {
+        try stdout_writer.print("Finished enumerating devices. Total found: {d}\n", .{device_counter}); // Escaped newline
+    }
 }


### PR DESCRIPTION
This commit introduces the following changes:

1. GitHub Actions Workflow (`.github/workflows/main.yml`):
   - Installs system dependencies for hidapi (libudev-dev, libusb-1.0-0-dev, pkg-config, autotools).
   - Clones the hidapi repository from GitHub.
   - Builds hidapi from source (bootstrap, configure, make, make install) and installs it into a workspace directory (`$GITHUB_WORKSPACE/hidapi_install`). CFLAGS="-fPIC" is used for the hidapi build.
   - Adds a step to execute the compiled Zig application on the Linux runner to display HID device information in the CI logs.

2. Zig Build System (`build.zig`):
   - Adds necessary include paths for the hidapi headers located in `hidapi_install/include/hidapi`.
   - Adds library paths for the hidapi library files in `hidapi_install/lib`.
   - Links the Zig executable against the static hidapi library (`libhidapi-hidraw.a`).
   - Links against required system libraries `udev` and `usb-1.0` for the Linux target.

3. Zig Application (`src/main.zig`):
   - Replaces the previous placeholder code with a new application that uses hidapi.
   - The application initializes hidapi via `hid_init()`.
   - Enumerates all connected HID devices using `hid_enumerate()`.
   - For each device, it prints information such as path, vendor ID, product ID, manufacturer string, and product string.
   - Includes a helper function to convert hidapi's `wchar_t*` strings to Zig strings for console output (with basic handling for non-ASCII characters).
   - Ensures `hid_exit()` is called before termination.

These changes allow your project to utilize hidapi for interacting with HID devices, with the initial functionality focused on enumerating and displaying device information within the GitHub Actions CI environment.