### PR TITLE
Refactor: Make main function a concise program runner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,39 @@
 use hidapi::HidApi;
 
-fn main() {
+fn print_hid_devices(api: &HidApi) {
+    for device in api.device_list() {
+        println!("  VID: {:04x}, PID: {:04x}", device.vendor_id(), device.product_id());
+
+        println!("    Path:           {}", device.path().to_string_lossy());
+        println!("    Interface #:    {}", device.interface_number());
+        println!("    Usage Page:     0x{:04x}", device.usage_page());
+
+        // CORRECTED: The method is .usage() not .usage_id()
+        println!("    Usage ID:       0x{:04x}", device.usage());
+
+        println!("    Product:        {}", device.product_string().unwrap_or("N/A"));
+        println!("    Manufacturer:   {}", device.manufacturer_string().unwrap_or("N/A"));
+        println!("    Serial:         {}", device.serial_number().unwrap_or("N/A"));
+        println!();
+    }
+}
+
+fn run_app() -> Result<(), String> {
     println!("Printing all available HID devices:");
     match HidApi::new() {
         Ok(api) => {
-            for device in api.device_list() {
-                println!("  VID: {:04x}, PID: {:04x}", device.vendor_id(), device.product_id());
-                
-                println!("    Path:           {}", device.path().to_string_lossy());
-                println!("    Interface #:    {}", device.interface_number());
-                println!("    Usage Page:     0x{:04x}", device.usage_page());
-                
-                // CORRECTED: The method is .usage() not .usage_id()
-                println!("    Usage ID:       0x{:04x}", device.usage());
-                
-                println!("    Product:        {}", device.product_string().unwrap_or("N/A"));
-                println!("    Manufacturer:   {}", device.manufacturer_string().unwrap_or("N/A"));
-                println!("    Serial:         {}", device.serial_number().unwrap_or("N/A"));
-                println!();
-            }
+            print_hid_devices(&api);
+            Ok(())
         }
         Err(e) => {
-            eprintln!("Error: {}", e);
+            Err(format!("Error initializing HidApi: {}", e))
         }
+    }
+}
+
+fn main() {
+    if let Err(e) = run_app() {
+        eprintln!("{}", e);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
I introduced a `run_app` function that encapsulates the primary application logic: initializing HIDAPI, listing devices, and handling errors.

The `main` function now solely calls `run_app` and handles its potential error, making it a clear and concise entry point for the program. This further improves modularity and follows the best practice of keeping the main function lean.